### PR TITLE
Allow using the configurations shipped in this project specifying the robot model name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ Makefile
 cmake_install.cmake
 install_manifest.txt
 CTestTestfile.cmake
+build/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,8 +2,11 @@ cmake_minimum_required(VERSION 2.8.11)
 
 project(icub-gazebo-wholebody)
 
-# Add models 
+# Add models
 add_subdirectory(models)
 
-# Add worlds 
+# Add worlds
 add_subdirectory(worlds)
+
+# Install the files
+install(DIRECTORY ${CMAKE_BINARY_DIR}/gazebo DESTINATION share)

--- a/README.md
+++ b/README.md
@@ -1,13 +1,36 @@
 # icub-gazebo-wholebody
-Gazebo models and worlds for simulating scenarios related to iCub Whole Body Control. 
+Gazebo models and worlds for simulating scenarios related to iCub Whole Body Control.
 
 The world and models in this repository are mantained by the [Dynamic Interaction Control Group](https://www.iit.it/research/lines/dynamic-interaction-controlicub-gazebo-wholebody) and are mostly related to whole body balancing and walking, related to the FP7 European Projects CoDyCo and Koroibot and the H2020 Project AnDy.
 
-# Usage 
-- `git clone` the repository on your computer.
-- Add `icub-gazebo-wholebody/models` to the `GAZEBO_MODEL_PATH` enviromental variable. 
+# Usage
 
-For more info see the [`icub-gazebo`](https://github.com/robotology/icub-gazebo) repository. 
+## From the build tree
 
-# Mantainer 
+If `<icub-gazebo-wholebody>` is the folder where this repository has been cloned, and the model you want to use is `iCubGenova04`, execute:
+
+```
+cd <icub-gazebo-wholebody>
+mkdir build
+cd build
+cmake -DROBOT_NAME=iCubGenova04 ..
+```
+
+After this, append `<icub-gazebo-wholebody>/build/gazebo/models` to the `GAZEBO_MODEL_PATH` enviromental variable.
+
+## From the install tree
+
+This project can be installed executing also:
+
+```
+cmake .. \
+      -DCMAKE_INSTALL_PREFIX=<prefix> \
+      -DROBOT_NAME=iCubGenova04
+cmake --build . --target install
+```
+
+For more info see the [`icub-gazebo`](https://github.com/robotology/icub-gazebo) and [`icub-models`](https://github.com/robotology-playground/icub-models) repositories.
+
+# Maintainer
+
 [Gabriele Nava](https://www.iit.it/it/people/gabriele-nava) ( [@gabrielenava](https://github.com/gabrielenava) ).

--- a/models/CMakeLists.txt
+++ b/models/CMakeLists.txt
@@ -23,7 +23,8 @@ set(ROBOT_NAME "" CACHE STRING "Select the the robot name that will match YARP_R
 
 # Check if YARP_ROBOT_NAME is defined as env variable
 if(ROBOT_NAME STREQUAL "")
-  message(FATAL_ERROR "ROBOT_NAME option is not defined. Pass it to CMake with -D")
+  message(WARNING "ROBOT_NAME option is not defined. Using icub as default for backwards compatibility")
+  set(ROBOT_NAME "icub")
 endif()
 
 # Setup the build tree

--- a/models/CMakeLists.txt
+++ b/models/CMakeLists.txt
@@ -18,14 +18,8 @@ macro(CONFIGURE_FILES srcDir destDir)
 
 endmacro(CONFIGURE_FILES)
 
-# Allow specifying the robot name
-set(ROBOT_NAME "" CACHE STRING "Select the the robot name that will match YARP_ROBOT_NAME")
-
-# Check if YARP_ROBOT_NAME is defined as env variable
-if(ROBOT_NAME STREQUAL "")
-  message(WARNING "ROBOT_NAME option is not defined. Using icub as default for backwards compatibility")
-  set(ROBOT_NAME "icub")
-endif()
+# Allow specifying the robot name (default to "icub" for backwards compatibility)
+set(ROBOT_NAME "icub" CACHE STRING "Select the the robot name that will also match the sdf's model://{ROBOT_NAME} (model folder searched by Gazebo)")
 
 # Setup the build tree
 CONFIGURE_FILES(${CMAKE_SOURCE_DIR}/models ${CMAKE_BINARY_DIR}/gazebo/)

--- a/models/CMakeLists.txt
+++ b/models/CMakeLists.txt
@@ -1,19 +1,30 @@
-# List the subdirectory (http://stackoverflow.com/questions/7787823/cmake-how-to-get-the-name-of-all-subdirectories-of-a-directory)
-macro(SUBDIRLIST result curdir)
-  file(GLOB children RELATIVE ${curdir} ${curdir}/*)
-  set(dirlist "")
-  foreach(child ${children})
-    if(IS_DIRECTORY ${curdir}/${child})
-      list(APPEND dirlist ${child})
+# configure_files for all files in a folder
+# https://stackoverflow.com/questions/697560/how-to-copy-directory-from-source-tree-to-binary-tree
+macro(CONFIGURE_FILES srcDir destDir)
+  make_directory(${destDir})
+  file(GLOB_RECURSE templateFiles RELATIVE ${srcDir} ${srcDir}/*)
+
+  foreach(templateFile ${templateFiles})
+    set(srcTemplatePath ${srcDir}/${templateFile})
+    message(${srcTemplatePath})
+
+    if(NOT IS_DIRECTORY ${srcTemplatePath})
+      configure_file(${srcTemplatePath}
+                     ${destDir}/${templateFile}
+                     @ONLY)
     endif()
-  endforeach()
-  set(${result} ${dirlist})
-endmacro()
 
-# Get list of models 
-subdirlist(subdirs ${CMAKE_CURRENT_SOURCE_DIR})
+  endforeach(templateFile)
 
-# Install each model 
-foreach (dir ${subdirs})
-  install (DIRECTORY ${dir} DESTINATION share/gazebo/models)
-endforeach ()
+endmacro(CONFIGURE_FILES)
+
+# Allow specifying the robot name
+set(ROBOT_NAME "" CACHE STRING "Select the the robot name that will match YARP_ROBOT_NAME")
+
+# Check if YARP_ROBOT_NAME is defined as env variable
+if(ROBOT_NAME STREQUAL "")
+  message(FATAL_ERROR "ROBOT_NAME option is not defined. Pass it to CMake with -D")
+endif()
+
+# Setup the build tree
+CONFIGURE_FILES(${CMAKE_SOURCE_DIR}/models ${CMAKE_BINARY_DIR}/gazebo/)

--- a/models/icub_fixed_no_hands/icub_fixed_no_hands.sdf
+++ b/models/icub_fixed_no_hands/icub_fixed_no_hands.sdf
@@ -1,8 +1,8 @@
 <?xml version='1.0'?>
-<sdf version='1.4'>
+<sdf version='1.5'>
   <model name="iCub_fixed_no_hands">
     <include>
-      <uri>model://icub</uri>
+      <uri>model://@ROBOT_NAME@</uri>
       <pose>0.0 0 1.0 0 0 3.14</pose>
     </include>
 

--- a/models/icub_fixed_no_hands/model.config
+++ b/models/icub_fixed_no_hands/model.config
@@ -1,15 +1,15 @@
 <?xml version="1.0"?>
 <model>
-    <name>iCub fixed (no hands)</name>
-    
+    <name>@ROBOT_NAME@ fixed (no hands)</name>
+
     <version>1.0</version>
     <sdf version='1.4'>icub_fixed_no_hands.sdf</sdf>
-    
+
     <author>
         <name>Silvio Traversaro</name>
         <email>silvio.traversaro@iit.it</email>
     </author>
-    
+
     <description>
         Model for the iCub humanoid robot. For more information check icub.org .
     </description>

--- a/models/icub_fixed_no_hands/model.config.in
+++ b/models/icub_fixed_no_hands/model.config.in
@@ -2,7 +2,7 @@
 <model>
     <name>@ROBOT_NAME@ fixed (no hands)</name>
 
-    <version>1.0</version>
+    <version>1.1</version>
     <sdf version='1.5'>icub_fixed_no_hands.sdf</sdf>
 
     <author>
@@ -11,6 +11,6 @@
     </author>
 
     <description>
-        Model for the iCub humanoid robot. For more information check icub.org .
+        Model for the iCub humanoid robot. For more information check icub.org.
     </description>
 </model>

--- a/models/icub_fixed_no_hands/model.config.in
+++ b/models/icub_fixed_no_hands/model.config.in
@@ -3,7 +3,7 @@
     <name>@ROBOT_NAME@ fixed (no hands)</name>
 
     <version>1.0</version>
-    <sdf version='1.4'>icub_fixed_no_hands.sdf</sdf>
+    <sdf version='1.5'>icub_fixed_no_hands.sdf</sdf>
 
     <author>
         <name>Silvio Traversaro</name>

--- a/worlds/CMakeLists.txt
+++ b/worlds/CMakeLists.txt
@@ -1,19 +1,2 @@
-# List the subdirectory (http://stackoverflow.com/questions/7787823/cmake-how-to-get-the-name-of-all-subdirectories-of-a-directory)
-macro(SUBDIRLIST result curdir)
-  file(GLOB children RELATIVE ${curdir} ${curdir}/*)
-  set(dirlist "")
-  foreach(child ${children})
-    if(IS_DIRECTORY ${curdir}/${child})
-      list(APPEND dirlist ${child})
-    endif()
-  endforeach()
-  set(${result} ${dirlist})
-endmacro()
-
-# Get list of models 
-subdirlist(subdirs ${CMAKE_CURRENT_SOURCE_DIR})
-
-# Install each model 
-foreach (dir ${subdirs})
-  install (DIRECTORY ${dir} DESTINATION share/gazebo/worlds)
-endforeach ()
+# Setup the build tree
+file(COPY ${CMAKE_SOURCE_DIR}/worlds DESTINATION ${CMAKE_BINARY_DIR}/gazebo)


### PR DESCRIPTION
I added the support of using the build tree of this project, and polished the `CMakeLists.txt` files. This changes will affect the usage of `icub-gazebo-wholebody` when the project is **not** installed.

In the past cloning the repository was enough. Right now instead, due to the switch to parametric configurations, the working tree will be inside the build folder with the robot model specified during the configure step.

This change allows easily switching between different models, it's just matter of changing the cmake's option `ROBOT_NAME`.

**For the time being, only the `icub_fixed_no_hands` has the support of different robot names**. Please test this for the time being.

FYI this is required in order to accomplish https://github.com/robotology-playground/icub-model-generator/issues/52

cc @robotology-playground/codyco-developers 