### PR TITLE
Add two icubs world

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ Makefile
 cmake_install.cmake
 install_manifest.txt
 CTestTestfile.cmake
+
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # icub-gazebo-wholebody
 Gazebo models and worlds for simulating scenarios related to iCub Whole Body Control. 
 
-The world and models in this repository are mantained by the [Dynamic Interaction Control Group](https://www.iit.it/research/lines/dynamic-interaction-controlicub-gazebo-wholebody) and are mostly related to whole body balancing and walking, related to the FP7 European Projects CoDyCo and Koroibot and the H2020 Project AnDy.
+The world and models in this repository are mantained by the [Dynamic Interaction Control Group](https://www.iit.it/research/lines/dynamic-interaction-control) and are mostly related to whole body balancing and walking, related to the FP7 European Projects CoDyCo and Koroibot and the H2020 Project AnDy.
 
 # Usage 
 - `git clone` the repository on your computer.

--- a/worlds/two_icubs_standup_world/README.md
+++ b/worlds/two_icubs_standup_world/README.md
@@ -1,0 +1,25 @@
+## To load two icubs standup world in Gazebo
+
+Normally, for loading a `world`, Gazebo needs to be launched in the folder where the `world` is. You can avoid this by appending these lines to your `.bashrc`:
+
+```
+source /usr/share/gazebo/setup.sh
+export GAZEBO_RESOURCE_PATH=$GAZEBO_RESOURCE_PATH:/PATH/WHERE/YOUR/WORLD/IS
+```
+
+Furthermore, if you are working with Simulink controllers, it is necessary to sincronize Gazebo with Simulink by running Gazebo with the option `-slibgazebo_yarp_clock.so`. 
+
+Final command to run in the terminal is something like this: `gazebo -slibgazebo_yarp_clock.so nameOfYourWorld`.
+
+For **two_icubs_standup** it is also necessary to avoid using the standard `gazeboYarpPluginsRobotName` for the two robots, otherwise the two models would share the name `icubSim` and the control boards of one of the two model fail.
+This can be done by editing [gazebo_icub_robotname.ini](https://github.com/robotology/icub-gazebo/blob/master/icub/conf/gazebo_icub_robotname.ini) file, and commenting out the following line:
+ ```
+ gazeboYarpPluginsRobotName icubSim
+ ```
+
+ When the world is created the two robots are not linked, but the model `iCub` is created with the [`linkattacher`](https://github.com/robotology/gazebo-yarp-plugins/tree/master/plugins/linkattacher) plugin that can be used to attach the robots hands:
+ ```
+ $ yarp rpc /iCub/linkattacher/rpc:i
+> attachUnscoped iCub l_hand iCub_0 r_hand
+> attachUnscoped iCub r_hand iCub_0 l_hand
+ ```

--- a/worlds/two_icubs_standup_world/two_icub_standup_world
+++ b/worlds/two_icubs_standup_world/two_icub_standup_world
@@ -1,0 +1,59 @@
+<?xml version="1.0"?>
+<sdf version="1.6">
+  <world name="default">
+
+    <!-- Light -->
+    <include>
+      <uri>model://sun</uri>
+    </include>
+
+    <!-- Ground Plane -->
+    <include>
+      <uri>model://ground_plane</uri>
+    </include>
+
+    <!-- Chair for sittin' on -->
+    <include>
+        <uri>model://chair</uri>
+    </include>
+    
+    <!-- iCub in the sitting position -->
+    <model name="iCub">
+      <plugin name='torso_configuration_override' filename='libgazebo_yarp_configurationoverride.so'>
+        <yarpPluginConfigurationOverride plugin_name='controlboard_torso'> </yarpPluginConfigurationOverride>
+        <initialConfiguration>0.0 0.0 0.0</initialConfiguration>
+      </plugin>
+      <plugin name='larm_configuration_override' filename='libgazebo_yarp_configurationoverride.so'>
+        <yarpPluginConfigurationOverride plugin_name='controlboard_left_arm_no_arm'> </yarpPluginConfigurationOverride>
+        <initialConfiguration>-0.6981 0.2094 1.3963 0.5585 0 0 0</initialConfiguration>
+      </plugin>
+      <plugin name='rarm_configuration_override' filename='libgazebo_yarp_configurationoverride.so'>
+        <yarpPluginConfigurationOverride plugin_name='controlboard_right_arm_no_arm'> </yarpPluginConfigurationOverride>
+        <initialConfiguration>-0.6981 0.2094 1.3963 0.5585 0 0 0</initialConfiguration>
+      </plugin>
+      <plugin name='lleg_configuration_override' filename='libgazebo_yarp_configurationoverride.so'>
+        <yarpPluginConfigurationOverride plugin_name='controlboard_left_leg'> </yarpPluginConfigurationOverride>
+        <initialConfiguration>1.5908 0.2141 0 -1.8176  -0.2142 0.0</initialConfiguration>
+      </plugin>
+      <plugin name='rleg_configuration_override' filename='libgazebo_yarp_configurationoverride.so'>
+        <yarpPluginConfigurationOverride plugin_name='controlboard_right_leg'> </yarpPluginConfigurationOverride>
+        <initialConfiguration>1.5908 0.2141 0 -1.8176  -0.2142 0.0</initialConfiguration>
+      </plugin>
+      <include>
+          <uri>model://icub</uri>
+      </include>
+      <plugin name='link_attacher' filename='libgazebo_yarp_linkattacher.so'>
+        <yarpConfigurationString>(name /iCub/linkattacher/rpc:i)</yarpConfigurationString>
+      </plugin>
+    </model>
+
+    <!-- iCub standing-->
+    <model name="iCub_0">
+      <include>
+          <uri>model://icub</uri>
+          <pose>0.6 0.0 0.6 0 0 0</pose>
+      </include>
+    </model>
+
+  </world>
+</sdf>


### PR DESCRIPTION
I think we can add the world with two icubs (one standing and one sitting) to the `devel` branch.
This world exploits some of the new features introduced recently in `gazebo-yarp-plugins/devel`:
- [`configurationOverride` plugin](https://github.com/robotology/gazebo-yarp-plugins/pull/401)
- [`linkattacher` refactoring](https://github.com/robotology/gazebo-yarp-plugins/pull/393)
- [`yarpConfigurationString` property](https://github.com/robotology/gazebo-yarp-plugins/pull/396)

It is important to notice what is written in the [`README.md`](https://github.com/robotology/icub-gazebo-wholebody/compare/devel...lrapetti:two_icubs_world?expand=1#diff-2f7bb1db2443ebbbd32e3e85beeea1e7R15) in order to properly run the world.